### PR TITLE
Specify product_dir in config file. Everything that follows

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ release = package.__version__
 # variables set in the global configuration. The variables set in the
 # global configuration are listed below, commented out.
 
-latex_elements['paper_size'] = 'a4'
+# latex_elements['paper_size'] = 'a4'
 
 # Add any paths that contain custom themes here, relative to this directory.
 # To use a different custom theme, add the directory containing the theme.

--- a/docs/scripts/cli.rst
+++ b/docs/scripts/cli.rst
@@ -143,8 +143,8 @@ SDTimage
                     [--sub] [--interactive] [--calibrate CALIBRATE] [--nofilt]
                     [-g] [-e EXCLUDE [EXCLUDE ...]] [--chans CHANS] [-o OUTFILE]
                     [-u UNIT] [--destripe] [--npix-tol NPIX_TOL] [--debug]
-                    [--quick] [--scrunch-channels] [--bad-chans BAD_CHANS]
-                    [--splat SPLAT]
+                    [--quick] [--scrunch-channels] [--nosave]
+                    [--bad-chans BAD_CHANS] [--splat SPLAT]
                     [file]
 
     Load a series of scans from a config file and produce a map.
@@ -188,6 +188,7 @@ SDTimage
       --quick               Calibrate after image creation, for speed (bad when
                             calibration depends on elevation)
       --scrunch-channels    Sum all the images from the single channels into one.
+      --nosave              Sum all the images from the single channels into one.
       --bad-chans BAD_CHANS
                             Channels to be discarded when scrunching, separated by
                             a comma (e.g. --bad-chans Feed2_RCP,Feed3_RCP )
@@ -323,7 +324,8 @@ SDTpreprocess
 .. code-block:: none
 
     usage: SDTpreprocess [-h] [-c CONFIG] [--sub] [--interactive] [--nofilt]
-                         [--debug] [--splat SPLAT] [-e EXCLUDE [EXCLUDE ...]]
+                         [--debug] [--nosave] [--splat SPLAT]
+                         [-e EXCLUDE [EXCLUDE ...]]
                          [files [files ...]]
 
     Load a series of scans from a config file and preprocess them, or preprocess a
@@ -340,6 +342,7 @@ SDTpreprocess
       --interactive         Open the interactive display for each scan
       --nofilt              Do not filter noisy channels
       --debug               Plot stuff and be verbose
+      --nosave              Sum all the images from the single channels into one.
       --splat SPLAT         Spectral scans will be scrunched into a single channel
                             containing data in the given frequency range, starting
                             from the frequency of the first bin. E.g. '0:1000'

--- a/docs/tutorials/converters.rst
+++ b/docs/tutorials/converters.rst
@@ -4,6 +4,14 @@ Italian antennas baded on the ACS control system save raw data in a FITS format 
 Users of other facilities might find it useful to have data converted in a known format.
 The SRT single dish tools have a convenient script for that, called ``SDTconvert``.
 
+.. note::
+
+    If you are using Anaconda: remember to initialize the environment. E.g. for an environment called ``py3``
+
+    .. code-block:: console
+
+        $ source activate py3
+
 
 Read logs and update information in fits files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/imaging.rst
+++ b/docs/tutorials/imaging.rst
@@ -14,6 +14,15 @@ Afterwards, we will load a set of calibrators to perform the
 conversion from signal level to Janskys/pixel. Finally, we will
 apply the calibration to the previously generated images.
 
+.. note::
+
+    If you are using Anaconda: remember to initialize the environment. E.g. for an environment called ``py3``
+
+    .. code-block:: console
+
+        $ source activate py3
+
+
 Inspect the observation
 ~~~~~~~~~~~~~~~~~~~~~~~
 During a night of observations, we will in general observe a number of calibrators

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[:2] < (3, 4):
     raise RuntimeError("Python version 2.7 or >= 3.4 required.")
 
 from astropy_helpers.setup_helpers import (
-    register_commands, adjust_compiler, get_debug_option, get_package_info)
+    register_commands, get_debug_option, get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
@@ -66,10 +66,6 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-adjust_compiler(PACKAGENAME)
 
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,

--- a/srttools/histograms.py
+++ b/srttools/histograms.py
@@ -243,7 +243,7 @@ def histogramdd(sample, bins=10, bin_range=None, normed=False, weights=None):
 
         # Remove outliers (indices 0 and -1 for each dimension).
         core = D*[slice(1, -1)]
-        hist = hist[core]
+        hist = hist[tuple(core)]
 
         # Normalize if normed is True
         if normed:

--- a/srttools/imager.py
+++ b/srttools/imager.py
@@ -1359,6 +1359,11 @@ def main_imager(args=None):
                         help='Sum all the images from the single channels into'
                              ' one.')
 
+    parser.add_argument("--nosave", action='store_true',
+                        default=False,
+                        help='Sum all the images from the single channels into'
+                             ' one.')
+
     parser.add_argument("--bad-chans",
                         default="", type=str,
                         help='Channels to be discarded when scrunching, '
@@ -1399,7 +1404,8 @@ def main_imager(args=None):
         scanset = ScanSet(args.config, norefilt=not args.refilt,
                           freqsplat=args.splat, nosub=not args.sub,
                           nofilt=args.nofilt, debug=args.debug,
-                          avoid_regions=excluded_radec)
+                          avoid_regions=excluded_radec,
+                          nosave=args.nosave)
         infile = args.config
 
         if outfile is None:
@@ -1450,6 +1456,11 @@ def main_preprocess(args=None):
     parser.add_argument("--debug", action='store_true', default=False,
                         help='Plot stuff and be verbose')
 
+    parser.add_argument("--nosave", action='store_true',
+                        default=False,
+                        help='Sum all the images from the single channels into'
+                             ' one.')
+
     parser.add_argument("--splat", type=str, default=None,
                         help=("Spectral scans will be scrunched into a single "
                               "channel containing data in the given frequency "
@@ -1480,7 +1491,8 @@ def main_preprocess(args=None):
                      norefilt=False, debug=args.debug,
                      interactive=args.interactive,
                      avoid_regions=excluded_radec,
-                     config_file=args.config)
+                     config_file=args.config,
+                     nosave=args.nosave)
             except OSError:
                 warnings.warn("File {} is not in a known format".format(f))
     else:
@@ -1488,4 +1500,5 @@ def main_preprocess(args=None):
             raise ValueError("Please specify the config file!")
         ScanSet(args.config, norefilt=False, freqsplat=args.splat,
                 nosub=not args.sub, nofilt=args.nofilt, debug=args.debug,
-                interactive=args.interactive, avoid_regions=excluded_radec)
+                interactive=args.interactive, avoid_regions=excluded_radec,
+                nosave=args.nosave)

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division,
                         print_function)
 import time
 import logging
+import os
 try:
     from watchdog.observers import Observer
     from watchdog.events import PatternMatchingEventHandler
@@ -14,6 +15,7 @@ import subprocess as sp
 import glob
 
 from srttools.read_config import read_config
+from srttools.scan import product_path_from_file_name
 warnings.filterwarnings('ignore')
 global CONFIG_FILE
 
@@ -46,13 +48,18 @@ class MyHandler(PatternMatchingEventHandler):
         global CONFIG_FILE
 
         infile = event.src_path
-        root = infile.replace('.fits', '')
         conf = read_config(CONFIG_FILE)
         ext = conf['debug_file_format']
+        productdir, fname = \
+            product_path_from_file_name(infile, productdir=conf['productdir'],
+                                        workdir=conf['workdir'])
+
+        root = os.path.join(productdir, fname.replace('.fits', ''))
+
         try:
             sp.check_call(
-                "SDTpreprocess --debug {} -c {}".format(infile,
-                                                        CONFIG_FILE).split())
+                "SDTpreprocess "
+                "--debug {} -c {}".format(infile, CONFIG_FILE).split())
         except sp.CalledProcessError:
             return
 

--- a/srttools/read_config.py
+++ b/srttools/read_config.py
@@ -29,6 +29,8 @@ def sample_config_file(fname='sample_config_file.ini'):
 workdir : .
 ; the root directory of the data repository.
 datadir : .
+; the root directory of the data repository.
+productdir : None
 
 [analysis]
 projection : ARC
@@ -114,6 +116,7 @@ def read_config(fname=None):
     config_output['interpolation'] = 'linear'
     config_output['workdir'] = './'
     config_output['datadir'] = './'
+    config_output['productdir'] = None
     config_output['list_of_directories'] = '*'
     config_output['calibrator_directories'] = []
     config_output['skydip_directories'] = []
@@ -140,6 +143,12 @@ def read_config(fname=None):
         config_output['datadir'] = \
             os.path.abspath(os.path.join(os.path.split(fname)[0],
                                          config_output['datadir']))
+
+    if config_output['productdir'] is not None and \
+            not config_output['productdir'].startswith('/'):
+        config_output['productdir'] = \
+            os.path.abspath(os.path.join(os.path.split(fname)[0],
+                                         config_output['productdir']))
 
     try:
         # Read analysis information

--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -278,7 +278,7 @@ def clean_scan_using_variability(dynamical_spectrum, length, bandwidth,
     srttools.fit.baseline_als
     srttools.fit.ref_mad
     """
-    rootdir, fn = os.path.split(outfile)
+    rootdir, _ = os.path.split(outfile)
     if not os.path.exists(rootdir):
         mkdir_p(rootdir)
 
@@ -927,7 +927,7 @@ class Scan(Table):
         if fname is None:
             fname = self.root_name(self.meta['filename']) + '.hdf5'
 
-        rootdir, fn = os.path.split(fname)
+        rootdir, _ = os.path.split(fname)
         if not os.path.exists(rootdir):
             mkdir_p(rootdir)
 

--- a/srttools/tests/data/spectrum.ini
+++ b/srttools/tests/data/spectrum.ini
@@ -4,6 +4,7 @@
 workdir : .
 ; the root directory of the data repository.
 datadir : .
+productdir : out_spectrum_test
 
 [analysis]
 projection : ARC

--- a/srttools/tests/data/test_config.ini
+++ b/srttools/tests/data/test_config.ini
@@ -1,6 +1,7 @@
 [local]
 workdir : .
 datadir : .
+productdir : test_out
 
 [analysis]
 projection : ARC
@@ -16,3 +17,6 @@ list_of_directories :
 ; Number of pixels, specified as pair x y
 
 pixel_size : 0.5
+
+[debugging]
+debug_file_format : jpg

--- a/srttools/tests/test_imager.py
+++ b/srttools/tests/test_imager.py
@@ -156,6 +156,10 @@ class TestScanSet(object):
         klass.curdir = os.path.dirname(__file__)
         klass.datadir = os.path.join(klass.curdir, 'data')
         klass.sim_dir = os.path.join(klass.datadir, 'sim')
+        klass.prodir_ra = os.path.join(klass.datadir,
+                                       'sim', 'test_image', 'gauss_ra')
+        klass.prodir_dec = os.path.join(klass.datadir,
+                                        'sim', 'test_image', 'gauss_dec')
 
         klass.obsdir_ra = os.path.join(klass.datadir, 'sim', 'gauss_ra')
         klass.obsdir_dec = os.path.join(klass.datadir, 'sim', 'gauss_dec')
@@ -247,7 +251,9 @@ class TestScanSet(object):
         for file in files[:2]:
             # I used debug_file_format : eps in the config
             if HAS_MPL:
-                assert os.path.exists(file.replace('.fits', '_0.eps'))
+                f = os.path.basename(file).replace('.fits', '_0.eps')
+
+                assert os.path.exists(os.path.join(self.prodir_ra, f))
 
     def test_script_is_installed_prep(self):
         sp.check_call('SDTpreprocess -h'.split(' '))
@@ -791,7 +797,6 @@ class TestScanSet(object):
         s = Scan(sname)
         assert np.all(after == s['Feed0_RCP-filt'])
         assert s.meta['FLAG'] is True
-        os.unlink(sname.replace('fits', 'hdf5'))
 
     def test_update_scan_fit(self):
         scanset = ScanSet('test.hdf5')
@@ -816,7 +821,7 @@ class TestScanSet(object):
         assert np.all(before != after)
         s = Scan(sname)
         assert np.all(after == s['Feed0_RCP'])
-        os.unlink(sname.replace('fits', 'hdf5'))
+        # os.unlink(sname.replace('fits', 'hdf5'))
 
     def test_update_scan_zap(self):
         scanset = ScanSet('test.hdf5')
@@ -845,7 +850,7 @@ class TestScanSet(object):
 
         assert np.all(np.array(after, dtype=bool) ==
                       np.array(s['Feed0_RCP-filt'], dtype=bool))
-        os.unlink(sname.replace('fits', 'hdf5'))
+        # os.unlink(sname.replace('fits', 'hdf5'))
 
     def test_imager_global_fit_invalid(self):
         '''Test image production.'''

--- a/srttools/tests/test_imager.py
+++ b/srttools/tests/test_imager.py
@@ -84,6 +84,7 @@ def sim_config_file(filename, add_garbage=False, prefix=None):
 [local]
 workdir : .
 datadir : .
+productdir : test_image
 
 [analysis]
 projection : ARC
@@ -952,9 +953,10 @@ class TestScanSet(object):
                 os.unlink(o)
             out_fits_files = glob.glob(os.path.join(klass.config['datadir'],
                                                     'test_config*.fits'))
-            out_hdf5_files = glob.glob(os.path.join(klass.config['datadir'],
+            out_hdf5_files = glob.glob(os.path.join(klass.config['productdir'],
                                                     'sim',
                                                     '*/', '*.hdf5'))
 
             for o in out_fits_files + out_hdf5_files:
                 os.unlink(o)
+            shutil.rmtree(os.path.join(klass.config['productdir'], 'sim'))

--- a/srttools/tests/test_io_and_scan.py
+++ b/srttools/tests/test_io_and_scan.py
@@ -47,14 +47,16 @@ class Test1_Scan(object):
             os.path.abspath(
                 os.path.join(klass.datadir, 'gauss_dec',
                              'Dec0.fits'))
-        h5file = klass.fname.replace('.fits', '.hdf5')
-        if os.path.exists(h5file):
-            os.unlink(h5file)
 
         klass.config_file = \
             os.path.abspath(os.path.join(klass.datadir, 'test_config.ini'))
 
-        read_config(klass.config_file)
+        config = read_config(klass.config_file)
+
+        h5file = os.path.join(config['productdir'], 'gauss_dec',
+                             'Dec0.hdf5')
+        if os.path.exists(h5file):
+            os.unlink(h5file)
 
     def test_bulk_change_hdr(self):
         dummyname = os.path.join(os.getcwd(), 'dummyfile.fits')
@@ -235,14 +237,15 @@ class Test2_Scan(object):
                 os.path.join(klass.datadir, 'spectrum',
                              'roach_template.fits'))
 
-        h5file = klass.fname.replace('.fits', '.hdf5')
-        if os.path.exists(h5file):
-            os.unlink(h5file)
         klass.config_file = \
             os.path.abspath(os.path.join(klass.datadir, 'spectrum.ini'))
-        print(klass.config_file)
+        config = read_config(klass.config_file)
 
-        read_config(klass.config_file)
+        h5file = os.path.join(config['productdir'], 'spectrum',
+                             'roach_template.hdf5')
+        if os.path.exists(h5file):
+            os.unlink(h5file)
+        klass.config = config
 
     def test_scan(self):
         '''Test that data are read.'''
@@ -260,6 +263,8 @@ class Test2_Scan(object):
         '''Test that data are read.'''
 
         Scan(os.path.join(self.datadir, 'spectrum', fname), debug=True)
+        assert os.path.exists(os.path.join(self.config['productdir'], 'spectrum',
+                                           fname.replace('.fits', '.hdf5')))
 
     def test_scan_baseline_unknown(self):
         '''Test that data are read.'''

--- a/srttools/tests/test_monitor.py
+++ b/srttools/tests/test_monitor.py
@@ -5,7 +5,9 @@ import subprocess as sp
 import threading
 import time
 import pytest
+from ..read_config import read_config
 from ..monitor import main_monitor, create_dummy_config, HAS_WATCHDOG
+from ..scan import product_path_from_file_name
 
 
 class TestMonitor(object):
@@ -16,13 +18,22 @@ class TestMonitor(object):
         klass.curdir = os.path.dirname(__file__)
         klass.datadir = os.path.join(klass.curdir, 'data')
         klass.specdir = os.path.join(klass.datadir, 'spectrum')
+        klass.config_file = \
+            os.path.abspath(os.path.join(klass.datadir, 'test_config.ini'))
+
+        config = read_config(klass.config_file)
+
+        dummy = os.path.join(klass.datadir, "srt_data_dummy.fits")
+        klass.proddir, _ = \
+            product_path_from_file_name(dummy, workdir=config['workdir'],
+                                        productdir=config['productdir'])
+
+        klass.config = config
 
         klass.file_empty_init = \
             os.path.abspath(os.path.join(klass.datadir, 'spectrum',
                                          "srt_data.fits"))
-        klass.file_empty = \
-            os.path.abspath(os.path.join(klass.datadir,
-                                         "srt_data_dummy.fits"))
+        klass.file_empty = os.path.abspath(dummy)
         klass.file_empty_hdf5 = \
             os.path.abspath(os.path.join(klass.datadir,
                                          "srt_data_dummy.hdf5"))
@@ -31,6 +42,15 @@ class TestMonitor(object):
                                          "srt_data_dummy_0.jpg"))
         klass.file_empty_pdf1 = \
             os.path.abspath(os.path.join(klass.datadir,
+                                         "srt_data_dummy_1.jpg"))
+        klass.file_empty_hdf5_alt = \
+            os.path.abspath(os.path.join(klass.proddir,
+                                         "srt_data_dummy.hdf5"))
+        klass.file_empty_pdf0_alt = \
+            os.path.abspath(os.path.join(klass.proddir,
+                                         "srt_data_dummy_0.jpg"))
+        klass.file_empty_pdf1_alt = \
+            os.path.abspath(os.path.join(klass.proddir,
                                          "srt_data_dummy_1.jpg"))
         if os.path.exists(klass.file_empty):
             os.unlink(klass.file_empty)
@@ -65,7 +85,7 @@ class TestMonitor(object):
 
     @pytest.mark.skipif('not HAS_WATCHDOG')
     def test_all_new_with_config(self):
-        fname = create_dummy_config()
+        fname = self.config_file
 
         def process():
             main_monitor([self.datadir, '--test', '-c', fname])
@@ -80,7 +100,7 @@ class TestMonitor(object):
         time.sleep(8)
         w.join()
 
-        for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
+        for fname in [self.file_empty_pdf0_alt, self.file_empty_pdf1_alt,
                       'latest_0.jpg', 'latest_1.jpg']:
             assert os.path.exists(fname)
             os.unlink(fname)
@@ -91,3 +111,4 @@ class TestMonitor(object):
             os.unlink(klass.file_empty)
         if os.path.exists(klass.file_empty_hdf5):
             os.unlink(klass.file_empty_hdf5)
+


### PR DESCRIPTION
Resolve #110. Not only do I specify a nosave option, but also can point all the intermediate hdf5 and image files to a product directory. This helps when the data directory is not writable.